### PR TITLE
Update example to use latest selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ exports.handler = function(event, context){
             .goto('https://duckduckgo.com')
             .type('#search_form_input_homepage', 'github nightmare')
             .click('#search_button_homepage')
-            .wait('#zero_click_wrapper .c-info__title a')
+            .wait('#r1-0 a.result__a')
             .evaluate(function () {
-                return document.querySelector('#zero_click_wrapper .c-info__title a').href;
+                return document.querySelector('#r1-0 a.result__a').href;
             })
             .end()
             .then(function (result) {
@@ -276,9 +276,9 @@ exports.handler = function(event, context){
     .goto('https://duckduckgo.com')
     .type('#search_form_input_homepage', 'github nightmare')
     .click('#search_button_homepage')
-    .wait('#zero_click_wrapper .c-info__title a')
+    .wait('#r1-0 a.result__a')
     .evaluate(function () {
-        return document.querySelector('#zero_click_wrapper .c-info__title a').href;
+        return document.querySelector('#r1-0 a.result__a').href;
     })
     .end()
     .then(function (result) {


### PR DESCRIPTION
Seems like DuckDuckGo changed their id naming convention, so the examples in the readme were no longer working.

This was fixed in Nightmare in https://github.com/segmentio/nightmare/pull/1232